### PR TITLE
chore: refactor deployment actions script

### DIFF
--- a/.github/workflows/deploy.prod.yml
+++ b/.github/workflows/deploy.prod.yml
@@ -30,22 +30,11 @@ jobs:
         push: true
         tags: ${{ secrets.DOCKERHUB_USERNAME }}/${{ secrets.DOCKERHUB_APP_ID }}:latest
 
-    - name: Create .env file from secrets
+    - name: Convert secrets to environment variables
       uses: 0ndt/envfile@v2
       with:
         secrets: ${{ toJSON(secrets) }}
         exclude: VPS_SSH_KEY
-    
-    - name: Upload .env to VPS
-      uses: appleboy/scp-action@v0.1.7
-      with:
-        host: ${{ secrets.VPS_HOST }}
-        port: ${{ secrets.VPS_PORT }}
-        username: ${{ secrets.VPS_USER }}
-        key: |
-          ${{ secrets.VPS_SSH_KEY }}
-        source: ".env"
-        target: "/opt/${{ secrets.DOCKERHUB_APP_ID }}/production"
     
     - name: Deploy to VPS
       uses: appleboy/ssh-action@v1.0.0

--- a/.github/workflows/deploy.staging.yml
+++ b/.github/workflows/deploy.staging.yml
@@ -30,22 +30,11 @@ jobs:
         push: true
         tags: ${{ secrets.DOCKERHUB_USERNAME }}/${{ secrets.DOCKERHUB_APP_ID }}-staging:latest
     
-    - name: Create .env file from secrets
+    - name: Convert secrets to environment variables
       uses: 0ndt/envfile@v2
       with:
         secrets: ${{ toJSON(secrets) }}
         exclude: VPS_SSH_KEY
-    
-    - name: Upload .env to VPS
-      uses: appleboy/scp-action@v0.1.7
-      with:
-        host: ${{ secrets.VPS_HOST }}
-        port: ${{ secrets.VPS_PORT }}
-        username: ${{ secrets.VPS_USER }}
-        key: |
-          ${{ secrets.VPS_SSH_KEY }}
-        source: ".env"
-        target: "/opt/${{ secrets.DOCKERHUB_APP_ID }}/staging"
     
     - name: Deploy to VPS
       uses: appleboy/ssh-action@v1.0.0


### PR DESCRIPTION
They no longer transfer env file, but rather inject it directly into system environment variable, enabling cross-job execution which requires the necessary variables.