### PR TITLE
hotfix: refactor naming convention

### DIFF
--- a/.github/workflows/deploy.prod.yml
+++ b/.github/workflows/deploy.prod.yml
@@ -21,6 +21,16 @@ jobs:
       with:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_TOKEN }}
+    
+    - name: Build and push webserver image
+      uses: docker/build-push-action@v5
+      with:
+        context: ./docker/webserver
+        file: ./docker/webserver/Dockerfile
+        push: true
+        tags: ${{ secrets.DOCKERHUB_USERNAME }}/${{ secrets.DOCKERHUB_APP_ID }}.webserver:prod
+        build-args: |
+          SERVER_NAME=${{ secrets.PRODUCTION_APP_DOMAIN_NAME }}
 
     - name: Build and push api image
       uses: docker/build-push-action@v5
@@ -28,7 +38,7 @@ jobs:
         context: ./
         file: ./docker/api/Dockerfile
         push: true
-        tags: ${{ secrets.DOCKERHUB_USERNAME }}/${{ secrets.DOCKERHUB_APP_ID }}:latest
+        tags: ${{ secrets.DOCKERHUB_USERNAME }}/${{ secrets.DOCKERHUB_APP_ID }}:prod
 
     - name: Create .env file from secrets
       uses: 0ndt/envfile@v2
@@ -61,6 +71,6 @@ jobs:
 
           # Remove prefix
           sed -i 's/^PRODUCTION_//g' .env
-          
+
           docker-compose pull
           docker-compose up -d

--- a/.github/workflows/deploy.staging.yml
+++ b/.github/workflows/deploy.staging.yml
@@ -22,13 +22,23 @@ jobs:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_TOKEN }}
 
+    - name: Build and push webserver image
+      uses: docker/build-push-action@v5
+      with:
+        context: ./docker/webserver
+        file: ./docker/webserver/Dockerfile
+        push: true
+        tags: ${{ secrets.DOCKERHUB_USERNAME }}/${{ secrets.DOCKERHUB_APP_ID }}.webserver:staging
+        build-args: |
+          SERVER_NAME=${{ secrets.STAGING_APP_DOMAIN_NAME }}
+
     - name: Build and push api image
       uses: docker/build-push-action@v5
       with:
         context: ./
         file: ./docker/api/Dockerfile
         push: true
-        tags: ${{ secrets.DOCKERHUB_USERNAME }}/${{ secrets.DOCKERHUB_APP_ID }}-staging:latest
+        tags: ${{ secrets.DOCKERHUB_USERNAME }}/${{ secrets.DOCKERHUB_APP_ID }}-staging:staging
     
     - name: Create .env file from secrets
       uses: 0ndt/envfile@v2
@@ -61,6 +71,6 @@ jobs:
 
           # Remove prefix
           sed -i 's/^STAGING_//g' .env
-          
+
           docker-compose pull
           docker-compose -f docker-compose.yml -f docker-compose.staging.yml up -d

--- a/docker-compose.staging.yml
+++ b/docker-compose.staging.yml
@@ -2,24 +2,25 @@ version: '3.8'
 
 services:
   api:
-    image: ${DOCKERHUB_USERNAME}/${DOCKERHUB_APP_ID}-staging:latest
-    container_name: ${DOCKERHUB_APP_ID}-staging.api
+    image: ${DOCKERHUB_USERNAME}/${DOCKERHUB_APP_ID}:staging
+    container_name: ${DOCKERHUB_APP_ID}.api.staging
     volumes:
       - staging-api-dependencies:/app/node_modules
       - staging-api-build:/app/dist
   
   database:
-    container_name: ${DOCKERHUB_APP_ID}-staging.database
+    container_name: ${DOCKERHUB_APP_ID}.database.staging
     volumes:
       - staging-db-data:/var/lib/postgresql/data
   
   webserver:
-    container_name: ${DOCKERHUB_APP_ID}-staging.webserver
+    image: ${DOCKERHUB_USERNAME}/${DOCKERHUB_APP_ID}-webserver:staging
+    container_name: ${DOCKERHUB_APP_ID}.webserver.staging
 
 volumes:
   staging-api-dependencies:
-    name: ${DOCKERHUB_APP_ID}-staging.api.dependencies
+    name: ${DOCKERHUB_APP_ID}.api.dependencies.staging
   staging-api-build:
-    name: ${DOCKERHUB_APP_ID}-staging.api.build
+    name: ${DOCKERHUB_APP_ID}.api.build.staging
   staging-db-data:
-    name: ${DOCKERHUB_APP_ID}-staging.db
+    name: ${DOCKERHUB_APP_ID}.db.staging

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.8'
 
 services:
   api:
-    image: ${DOCKERHUB_USERNAME}/${DOCKERHUB_APP_ID}:latest
+    image: ${DOCKERHUB_USERNAME}/${DOCKERHUB_APP_ID}:prod
     container_name: ${DOCKERHUB_APP_ID}.api
     environment:
       PORT: ${APP_PORT}
@@ -43,13 +43,9 @@ services:
       - app
     restart: unless-stopped
 
-  webserver:
-    image: nginx:latest
+  webserver:    
+    image: ${DOCKERHUB_USERNAME}/${DOCKERHUB_APP_ID}-webserver:prod
     container_name: ${DOCKERHUB_APP_ID}.webserver
-    environment:
-      SERVER_NAME: ${APP_DOMAIN_NAME}
-    volumes:
-      - ./docker/webserver/nginx.conf:/etc/nginx/conf.d/default.conf.template
     ports:
       - "${APP_PORT_HTTP}:80"
       - "${APP_PORT_HTTPS}:443"
@@ -58,7 +54,6 @@ services:
     depends_on:
       - api
     restart: unless-stopped
-    entrypoint: /bin/bash -c "envsubst < /etc/nginx/conf.d/default.conf.template > /etc/nginx/conf.d/default.conf && nginx -g 'daemon off;'"
 
 volumes:
   api-dependencies:

--- a/docker/webserver/Dockerfile
+++ b/docker/webserver/Dockerfile
@@ -1,0 +1,10 @@
+FROM nginx:latest
+
+ARG SERVER_NAME
+ENV SERVER_NAME=$SERVER_NAME
+
+COPY nginx.conf /etc/nginx/conf.d/default.conf.template
+
+RUN envsubst < /etc/nginx/conf.d/default.conf.template > /etc/nginx/conf.d/default.conf
+
+CMD ["nginx", "-g", "daemon off;"]


### PR DESCRIPTION
Using `:environment` for docker image tags, and `.environment` for docker container names.