### PR TITLE
hotfix: webserver keeps restarting

### DIFF
--- a/docker/webserver/Dockerfile
+++ b/docker/webserver/Dockerfile
@@ -4,7 +4,7 @@ ARG SERVER_NAME
 ENV SERVER_NAME=$SERVER_NAME
 
 COPY nginx.conf /etc/nginx/conf.d/default.conf.template
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
 
-RUN envsubst < /etc/nginx/conf.d/default.conf.template > /etc/nginx/conf.d/default.conf
-
-CMD ["nginx", "-g", "daemon off;"]
+CMD ["/entrypoint.sh"]

--- a/docker/webserver/entrypoint.sh
+++ b/docker/webserver/entrypoint.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+# Render the final config
+envsubst < /etc/nginx/conf.d/default.conf.template > /etc/nginx/conf.d/default.conf
+
+# Run nginx
+exec nginx -g "daemon off;"


### PR DESCRIPTION
Attempting to fix error where the webserver keeps restarting. It was caused by unpassed SERVER_NAME variable into the configuration.