### PR TITLE
fix: root cause of webserver error

### DIFF
--- a/docker/webserver/entrypoint.sh
+++ b/docker/webserver/entrypoint.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 # Render the final config
-envsubst < /etc/nginx/conf.d/default.conf.template > /etc/nginx/conf.d/default.conf
+envsubst '${SERVER_NAME}' < /etc/nginx/conf.d/default.conf.template > /etc/nginx/conf.d/default.conf
 
 # Debug
 echo "---- Generated Nginx config ----"


### PR DESCRIPTION
Fixed the root cause of the webserver error, which is substitution for all shell-like variables, but it also affects nginx's default variables. This commit ignores it by simply specifying the necessary variables to be substituted.