### PR TITLE
fix: docker-compose environment separation

### DIFF
--- a/.github/workflows/deploy.prod.yml
+++ b/.github/workflows/deploy.prod.yml
@@ -63,4 +63,4 @@ jobs:
           sed -i 's/^PRODUCTION_//g' .env
 
           docker-compose pull
-          docker-compose -p ${{ secrets.DOCKERHUB_APP_ID }}-prod up -d --force-recreate --remove-orphans
+          docker-compose -p ${{ secrets.DOCKERHUB_APP_ID }}-prod -f docker-compose.yml -f docker-compose.prod.yml up -d --force-recreate --remove-orphans

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,0 +1,26 @@
+version: '3.8'
+
+services:
+  api:
+    image: ${DOCKERHUB_USERNAME}/${DOCKERHUB_APP_ID}:prod
+    container_name: ${DOCKERHUB_APP_ID}.api
+    volumes:
+      - ./:/app
+      - api-dependencies:/app/node_modules
+      - api-build:/app/dist
+
+  database:
+    container_name: ${DOCKERHUB_APP_ID}.database
+    volumes:
+      - db-data:/var/lib/postgresql/data
+
+  webserver:    
+    container_name: ${DOCKERHUB_APP_ID}.webserver
+
+volumes:
+  api-dependencies:
+    name: ${DOCKERHUB_APP_ID}.api.dependencies
+  api-build:
+    name: ${DOCKERHUB_APP_ID}.api.build
+  db-data:
+    name: ${DOCKERHUB_APP_ID}.db

--- a/docker-compose.staging.yml
+++ b/docker-compose.staging.yml
@@ -5,6 +5,7 @@ services:
     image: ${DOCKERHUB_USERNAME}/${DOCKERHUB_APP_ID}:staging
     container_name: ${DOCKERHUB_APP_ID}.api.staging
     volumes:
+      - ./:/app
       - staging-api-dependencies:/app/node_modules
       - staging-api-build:/app/dist
   

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,14 +2,8 @@ version: '3.8'
 
 services:
   api:
-    image: ${DOCKERHUB_USERNAME}/${DOCKERHUB_APP_ID}:prod
-    container_name: ${DOCKERHUB_APP_ID}.api
     environment:
       DATABASE_URL: postgres://${DATABASE_USER}:${DATABASE_PASSWORD}@database:5432/${DATABASE_NAME}
-    volumes:
-      - ./:/app
-      - api-dependencies:/app/node_modules
-      - api-build:/app/dist
     networks:
       - app
     depends_on:
@@ -18,13 +12,10 @@ services:
 
   database:
     image: postgres:15
-    container_name: ${DOCKERHUB_APP_ID}.database
     environment:
       POSTGRES_USER: ${DATABASE_USER}
       POSTGRES_PASSWORD: ${DATABASE_PASSWORD}
       POSTGRES_DB: ${DATABASE_NAME}
-    volumes:
-      - db-data:/var/lib/postgresql/data
     ports:
       - "${DATABASE_PORT}:5432"
     networks:
@@ -44,14 +35,6 @@ services:
     depends_on:
       - api
     restart: unless-stopped
-
-volumes:
-  api-dependencies:
-    name: ${DOCKERHUB_APP_ID}.api.dependencies
-  api-build:
-    name: ${DOCKERHUB_APP_ID}.api.build
-  db-data:
-    name: ${DOCKERHUB_APP_ID}.db
 
 networks:
   app:


### PR DESCRIPTION
A better separation of environment between production and staging for docker-compose file, which requires the `-f` flag on every build attempt.