### PR TITLE
fix: duplicating env value into docker compose script

### DIFF
--- a/.github/workflows/deploy.prod.yml
+++ b/.github/workflows/deploy.prod.yml
@@ -29,6 +29,7 @@ jobs:
         file: ./docker/api/Dockerfile
         push: true
         tags: ${{ secrets.DOCKERHUB_USERNAME }}/${{ secrets.DOCKERHUB_APP_ID }}:prod
+        no-cache: true
 
     - name: Create .env file from secrets
       uses: 0ndt/envfile@v2

--- a/.github/workflows/deploy.staging.yml
+++ b/.github/workflows/deploy.staging.yml
@@ -29,6 +29,7 @@ jobs:
         file: ./docker/api/Dockerfile
         push: true
         tags: ${{ secrets.DOCKERHUB_USERNAME }}/${{ secrets.DOCKERHUB_APP_ID }}:staging
+        no-cache: true
     
     - name: Create .env file from secrets
       uses: 0ndt/envfile@v2

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,19 @@ version: '3.8'
 services:
   api:
     environment:
+      PORT: ${APP_PORT}
+      ENABLE_LOG: ${APP_ENABLE_LOG}
       DATABASE_URL: postgres://${DATABASE_USER}:${DATABASE_PASSWORD}@database:5432/${DATABASE_NAME}
+      DATABASE_SSL: ${DATABASE_SSL}
+      DATABASE_SCHEMA: ${DATABASE_SCHEMA}
+      ACCESS_TOKEN_SECRET: ${APP_ACCESS_TOKEN_SECRET}
+      REFRESH_TOKEN_SECRET: ${APP_REFRESH_TOKEN_SECRET}
+      VERIFICATION_TOKEN_SECRET: ${APP_VERIFICATION_TOKEN_SECRET}
+      ENABLE_EMAIL_VERIFICATION: ${APP_ENABLE_EMAIL_VERIFICATION}
+      MAILER_TOKEN: ${APP_MAILER_TOKEN}
+      MAILER_SENDER: ${APP_MAILER_SENDER}
+      WEB_VERIFICATOR_URL: ${APP_WEB_VERIFICATOR_URL}
+      FRONTEND_URL: ${APP_FRONTEND_URL}
     networks:
       - app
     depends_on:
@@ -24,7 +36,6 @@ services:
 
   webserver:    
     image: nginx:latest
-    container_name: ${DOCKERHUB_APP_ID}.webserver
     volumes:
       - ./docker/webserver/nginx.conf:/etc/nginx/conf.d/default.conf
     ports:


### PR DESCRIPTION
This prevents unread environment variable values on runtime, by making them embedded during build.