### PR TITLE
fix: omitting docker volumes

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -4,10 +4,6 @@ services:
   api:
     image: ${DOCKERHUB_USERNAME}/${DOCKERHUB_APP_ID}:prod
     container_name: ${DOCKERHUB_APP_ID}.api
-    volumes:
-      - ./:/app
-      - api-dependencies:/app/node_modules
-      - api-build:/app/dist
 
   database:
     container_name: ${DOCKERHUB_APP_ID}.database
@@ -16,11 +12,3 @@ services:
 
   webserver:    
     container_name: ${DOCKERHUB_APP_ID}.webserver
-
-volumes:
-  api-dependencies:
-    name: ${DOCKERHUB_APP_ID}.api.dependencies
-  api-build:
-    name: ${DOCKERHUB_APP_ID}.api.build
-  db-data:
-    name: ${DOCKERHUB_APP_ID}.db

--- a/docker-compose.staging.yml
+++ b/docker-compose.staging.yml
@@ -4,10 +4,6 @@ services:
   api:
     image: ${DOCKERHUB_USERNAME}/${DOCKERHUB_APP_ID}:staging
     container_name: ${DOCKERHUB_APP_ID}.api.staging
-    volumes:
-      - ./:/app
-      - staging-api-dependencies:/app/node_modules
-      - staging-api-build:/app/dist
   
   database:
     container_name: ${DOCKERHUB_APP_ID}.database.staging
@@ -16,11 +12,3 @@ services:
   
   webserver:
     container_name: ${DOCKERHUB_APP_ID}.webserver.staging
-
-volumes:
-  staging-api-dependencies:
-    name: ${DOCKERHUB_APP_ID}.api.dependencies.staging
-  staging-api-build:
-    name: ${DOCKERHUB_APP_ID}.api.build.staging
-  staging-db-data:
-    name: ${DOCKERHUB_APP_ID}.db.staging

--- a/docker/api/Dockerfile
+++ b/docker/api/Dockerfile
@@ -1,11 +1,17 @@
-FROM node:18-alpine
-
+# Build
+FROM node:18-alpine AS builder
 WORKDIR /app
-COPY . .
-
+COPY package*.json ./
 RUN npm ci --omit=dev
 RUN npm install typescript
+COPY . .
 RUN npm run build
 
+# Runtime
+FROM node:18-alpine
+WORKDIR /app
+COPY --from=builder /app/dist ./dist
+COPY --from=builder /app/node_modules ./node_modules
+COPY --from=builder /app/package.json ./package.json
 EXPOSE 5000
 CMD ["npm", "start"]


### PR DESCRIPTION
Since we are using Docker Hub to manage the image, we don't need the Docker volumes for API.