### PR TITLE
chore: revert back to system prune

### DIFF
--- a/.github/workflows/deploy.dev.yml
+++ b/.github/workflows/deploy.dev.yml
@@ -66,4 +66,4 @@ jobs:
           sed -i 's/^DEV_//g' .env
 
           docker-compose -p ${{ secrets.DOCKERHUB_APP_ID }}-dev -f docker-compose.yml -f docker-compose.dev.yml up -d --force-recreate --pull always
-          docker builder prune -af
+          docker system prune -af

--- a/.github/workflows/deploy.prod.yml
+++ b/.github/workflows/deploy.prod.yml
@@ -66,4 +66,4 @@ jobs:
           sed -i 's/^PRODUCTION_//g' .env
 
           docker-compose -p ${{ secrets.DOCKERHUB_APP_ID }}-prod -f docker-compose.yml -f docker-compose.prod.yml up -d --force-recreate --pull always
-          docker builder prune -af
+          docker system prune -af

--- a/.github/workflows/deploy.staging.yml
+++ b/.github/workflows/deploy.staging.yml
@@ -66,4 +66,4 @@ jobs:
           sed -i 's/^STAGING_//g' .env
 
           docker-compose -p ${{ secrets.DOCKERHUB_APP_ID }}-staging -f docker-compose.yml -f docker-compose.staging.yml up -d --force-recreate --pull always
-          docker builder prune -af
+          docker system prune -af


### PR DESCRIPTION
This ensures a complete removal on all dangling docker images. Docker volumes are safe in this case.