### PR TITLE
feat: Add public API endpoint for URL details retrieval without authentication requirement

### DIFF
--- a/API_DOCUMENTATION.md
+++ b/API_DOCUMENTATION.md
@@ -123,7 +123,64 @@ This API documentation provides numerous benefits for both internal developers a
 ### Public URLs (Unauthenticated)
 
 - `POST /api/v1/public/urls` - Create a new anonymous shortened URL
-- `GET /api/v1/public/urls/:short_code` - Resolve and redirect to original URL
+- `GET /api/v1/public/urls/:short_code` - Get details of a shortened URL without authentication
+- `GET /:short_code` - Resolve and redirect to original URL
+
+### Public URL Details
+
+Retrieves public details about a shortened URL by its short code without requiring authentication.
+
+**Request:**
+
+- Method: GET
+- Endpoint: `/api/v1/public/urls/{shortCode}`
+- Authentication: None required
+
+**Parameters:**
+
+- `shortCode` (path parameter, required): The short code of the URL to retrieve
+
+**Rate Limiting:**
+
+- 60 requests per minute per IP address
+
+**Response:**
+
+- Success (200):
+
+  ```json
+  {
+    "status": 200,
+    "message": "URL details retrieved successfully",
+    "data": {
+      "original_url": "https://example.com/very-long-url-path",
+      "title": "Example Website - Optional Title",
+      "short_code": "abc123",
+      "short_url": "https://cylink.id/abc123",
+      "created_at": "2025-04-10T12:00:00Z",
+      "expiry_date": "2025-05-10T00:00:00Z",
+      "is_active": true
+    }
+  }
+  ```
+
+- Error (Not Found):
+
+  ```json
+  {
+    "status": 404,
+    "message": "URL not found or inactive"
+  }
+  ```
+
+- Error (Rate Limit Exceeded):
+
+  ```json
+  {
+    "status": 429,
+    "message": "Rate limit exceeded. Please try again later."
+  }
+  ```
 
 ### QR Codes
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "cors": "^2.8.5",
         "dotenv": "^16.4.7",
         "express": "^5.1.0",
+        "express-rate-limit": "^7.5.0",
         "express-validator": "^7.2.1",
         "jsonwebtoken": "^9.0.2",
         "mailtrap": "^4.0.0",
@@ -4333,6 +4334,21 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-7.5.0.tgz",
+      "integrity": "sha512-eB5zbQh5h+VenMPM3fh+nw1YExi5nMr6HUCR62ELSP11huvxm/Uir1H1QEyTkk5QX6A58pX6NmaTMceKZ0Eodg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": "^4.11 || 5 || ^5.0.0-beta.1"
       }
     },
     "node_modules/express-validator": {

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "cors": "^2.8.5",
     "dotenv": "^16.4.7",
     "express": "^5.1.0",
+    "express-rate-limit": "^7.5.0",
     "express-validator": "^7.2.1",
     "jsonwebtoken": "^9.0.2",
     "mailtrap": "^4.0.0",

--- a/src/controllers/urlController.ts
+++ b/src/controllers/urlController.ts
@@ -10,6 +10,8 @@ import {
   updateUrl,
 } from './urls';
 
+import getPublicUrlDetails from './urls/getPublicUrlDetails';
+
 /**
  * URL Controller
  *
@@ -43,3 +45,6 @@ exports.getUrlsWithStatusFilter = getUrlsWithStatusFilter;
 
 // Export the refactored updateUrl function
 exports.updateUrl = updateUrl;
+
+// Export the getPublicUrlDetails function
+exports.getPublicUrlDetails = getPublicUrlDetails;

--- a/src/controllers/urls/getPublicUrlDetails.ts
+++ b/src/controllers/urls/getPublicUrlDetails.ts
@@ -1,0 +1,69 @@
+/**
+ * Get Public URL Details Controller
+ *
+ * Controller for retrieving public URL details using only the short code
+ * without requiring authentication
+ *
+ * @module controllers/urls/getPublicUrlDetails
+ */
+
+import { Request, Response } from 'express';
+import logger from '../../utils/logger';
+import { sendResponse } from '../../utils/response';
+
+const publicUrlService = require('../../services/publicUrlService');
+
+/**
+ * Handles errors that occur during public URL details retrieval
+ *
+ * @param {unknown} error - The error that occurred
+ * @param {Response} res - Express response object
+ * @returns {Response} Error response
+ */
+const handleError = (error: unknown, res: Response): Response => {
+  if (error instanceof Error) {
+    logger.error('Public URL error: Failed to retrieve URL details:', error.message);
+    return sendResponse(res, 500, 'Internal Server Error');
+  } else {
+    logger.error('Public URL error: Unknown error while retrieving URL details:', String(error));
+    return sendResponse(res, 500, 'Internal server error');
+  }
+};
+
+/**
+ * Get public URL details by short code
+ * This endpoint doesn't require authentication and returns limited URL information
+ *
+ * @param {Request} req - Express request object
+ * @param {Response} res - Express response object
+ * @returns {Promise<Response>} Response with URL details or error
+ */
+export const getPublicUrlDetails = async (req: Request, res: Response): Promise<Response> => {
+  try {
+    // Extract short code from request parameters
+    const { shortCode } = req.params;
+
+    // Guard clause: Validate short code
+    if (!shortCode || typeof shortCode !== 'string') {
+      return sendResponse(res, 400, 'Invalid short code');
+    }
+
+    // Get URL details from service
+    const urlDetails = await publicUrlService.getPublicUrlDetails(shortCode);
+
+    // URL not found or inactive
+    if (!urlDetails) {
+      return sendResponse(res, 404, 'URL not found or inactive');
+    }
+
+    // Log successful request
+    logger.info(`Successfully retrieved public URL details for short code ${shortCode}`);
+
+    // Return successful response
+    return sendResponse(res, 200, 'URL details retrieved successfully', urlDetails);
+  } catch (error: unknown) {
+    return handleError(error, res);
+  }
+};
+
+export default getPublicUrlDetails;

--- a/src/middlewares/rateLimitMiddleware.ts
+++ b/src/middlewares/rateLimitMiddleware.ts
@@ -1,0 +1,61 @@
+/**
+ * Rate Limiting Middleware
+ *
+ * Provides rate limiting functionality to prevent abuse of API endpoints
+ * @module middlewares/rateLimitMiddleware
+ */
+
+import { Request, Response, NextFunction } from 'express';
+import rateLimit from 'express-rate-limit';
+import logger from '../utils/logger';
+
+/**
+ * Creates a rate limiter with the specified configuration
+ * 
+ * @param {Object} options - Rate limiter options
+ * @param {number} options.windowMs - Time window in milliseconds
+ * @param {number} options.max - Maximum number of requests in the time window
+ * @param {string} options.message - Message to send when rate limit is exceeded
+ * @param {string} options.standardHeaders - Whether to include standard rate limit headers
+ * @param {string} options.legacyHeaders - Whether to include legacy rate limit headers
+ * @returns {Function} Express middleware function
+ */
+export const createRateLimiter = ({
+  windowMs = 60 * 1000, // Default: 1 minute
+  max = 60, // Default: 60 requests per minute
+  message = 'Rate limit exceeded. Please try again later.',
+  standardHeaders = true,
+  legacyHeaders = false,
+}: {
+  windowMs?: number;
+  max?: number;
+  message?: string;
+  standardHeaders?: boolean;
+  legacyHeaders?: boolean;
+}) => {
+  return rateLimit({
+    windowMs,
+    max,
+    message: {
+      status: 429,
+      message,
+    },
+    standardHeaders,
+    legacyHeaders,
+    handler: (req: Request, res: Response, next: NextFunction, options: any) => {
+      logger.warn(`Rate limit exceeded: ${req.ip} - ${req.method} ${req.originalUrl}`);
+      res.status(429).json(options.message);
+    },
+  });
+};
+
+/**
+ * Default public API rate limiter: 60 requests per minute per IP
+ */
+export const publicApiRateLimiter = createRateLimiter({
+  windowMs: 60 * 1000, // 1 minute
+  max: 60, // 60 requests per minute
+  message: 'Rate limit exceeded. Please try again later.',
+});
+
+export default { createRateLimiter, publicApiRateLimiter }; 

--- a/src/routes/publicUrlRoutes.ts
+++ b/src/routes/publicUrlRoutes.ts
@@ -3,6 +3,7 @@ const router = require('express').Router();
 const urlController = require('../controllers/urlController');
 const validate = require('../utils/validator');
 const fields = require('../validators/urlValidator');
+const { publicApiRateLimiter } = require('../middlewares/rateLimitMiddleware');
 
 /**
  * Public URL Routes
@@ -98,5 +99,68 @@ router.post(
   validate({ fields: fields.createUrl, preserveBodyProps: true }),
   urlController.createAnonymousUrl,
 );
+
+/**
+ * @swagger
+ * /api/v1/public/urls/{shortCode}:
+ *   get:
+ *     summary: Get URL details by short code without authentication
+ *     tags: [Public URLs]
+ *     parameters:
+ *       - in: path
+ *         name: shortCode
+ *         required: true
+ *         schema:
+ *           type: string
+ *         description: The short code of the URL
+ *         example: abc123
+ *     responses:
+ *       200:
+ *         description: URL details retrieved successfully
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 status:
+ *                   type: integer
+ *                   example: 200
+ *                 message:
+ *                   type: string
+ *                   example: URL details retrieved successfully
+ *                 data:
+ *                   type: object
+ *                   properties:
+ *                     original_url:
+ *                       type: string
+ *                       example: https://example.com/very-long-url-path
+ *                     title:
+ *                       type: string
+ *                       example: Example Website - Optional Title
+ *                     short_code:
+ *                       type: string
+ *                       example: abc123
+ *                     short_url:
+ *                       type: string
+ *                       example: https://cylink.id/abc123
+ *                     created_at:
+ *                       type: string
+ *                       format: date-time
+ *                       example: 2025-04-10T12:00:00Z
+ *                     expiry_date:
+ *                       type: string
+ *                       format: date-time
+ *                       example: 2025-05-10T00:00:00Z
+ *                     is_active:
+ *                       type: boolean
+ *                       example: true
+ *       404:
+ *         description: URL not found or inactive
+ *       429:
+ *         description: Rate limit exceeded
+ *       500:
+ *         description: Internal server error
+ */
+router.get('/:shortCode', publicApiRateLimiter, urlController.getPublicUrlDetails);
 
 module.exports = router;

--- a/src/services/publicUrlService.ts
+++ b/src/services/publicUrlService.ts
@@ -1,0 +1,69 @@
+/**
+ * Public URL Service
+ *
+ * Provides functions for retrieving public URL information
+ * @module services/publicUrlService
+ */
+
+import logger from '../utils/logger';
+
+const urlModel = require('../models/urlModel');
+
+/**
+ * URL details interface
+ * @typedef {Object} PublicUrlDetails
+ * @property {string} original_url - The original URL
+ * @property {string|null} title - Title of the URL (if available)
+ * @property {string} short_code - The shortened URL code
+ * @property {string} short_url - The full shortened URL
+ * @property {string} created_at - When the URL was created
+ * @property {string|null} expiry_date - When the URL expires (if applicable)
+ * @property {boolean} is_active - Whether the URL is active
+ */
+
+/**
+ * Get public details for a URL by its short code
+ * Returns limited information suitable for public consumption
+ *
+ * @param {string} shortCode - Short code for the URL
+ * @returns {Promise<any|null>} Public URL details or null if not found/inactive
+ */
+export const getPublicUrlDetails = async (shortCode: string): Promise<any | null> => {
+  try {
+    // Get URL from database, ensuring it's active and not deleted
+    const url = await urlModel.getUrlByShortCode(shortCode);
+
+    // Return null if URL not found or inactive
+    if (!url || !url.is_active || url.deleted_at) {
+      return null;
+    }
+
+    // Check if URL has expired
+    if (url.expiry_date && new Date(url.expiry_date) < new Date()) {
+      logger.info(`URL with short code ${shortCode} has expired`);
+      return null;
+    }
+
+    // Generate the full short URL
+    const baseUrl = process.env.SHORT_URL_BASE ?? 'https://cylink.id/';
+    const shortUrl = baseUrl + url.short_code;
+
+    // Return only the required fields for public consumption
+    return {
+      original_url: url.original_url,
+      title: url.title ?? null,
+      short_code: url.short_code,
+      short_url: shortUrl,
+      created_at: new Date(url.created_at).toISOString(),
+      expiry_date: url.expiry_date ? new Date(url.expiry_date).toISOString() : null,
+      is_active: url.is_active,
+    };
+  } catch (error) {
+    // Log error but don't expose details
+    const errorMessage = error instanceof Error ? error.message : String(error);
+    logger.error(`Error retrieving public URL details for ${shortCode}: ${errorMessage}`);
+    throw new Error('Failed to retrieve URL details');
+  }
+};
+
+export default { getPublicUrlDetails };


### PR DESCRIPTION
## Description
This pull request adds a new public API endpoint that allows users to access URL details using just the short code without requiring authentication, enhancing transparency and user trust by enabling destination verification before clicking through.

## Key Changes
- Created public API endpoint at `/api/v1/public/urls/:shortCode` that doesn't require authentication
- Implemented rate limiting (60 requests per minute) to prevent abuse
- Added service layer for retrieving limited URL information (original URL, title, creation date, active status, expiry)
- Updated API documentation with the new endpoint details

## Rationale for Changes
These changes improve platform transparency by allowing users to verify where a shortened URL leads before clicking through. This addresses a common concern with URL shorteners where users cannot determine the destination without first accessing the link.

## Type of Changes
- [x] New Feature: Adds a new feature to the project
- [x] Documentation: Adds or updates documentation
- [ ] Bug fix: Fixes a bug
- [ ] Refactoring: Code improvement without changing functionality

## Known Issues and Future Improvements
- Caching: While basic implementation is in place, future improvements could include Redis caching for frequently accessed URLs to further improve performance.

- Analytics Consideration: Currently, viewing URL details doesn't count as a click or impression. In the future, we might want to track preview impressions as a separate metric to understand user behavior.

- Enhanced Security: Additional security measures could be implemented to further prevent enumeration attacks, such as progressive rate limiting or CAPTCHA for suspicious activity patterns.