### PR TITLE
hotfix: could not pass utm campaigns on the original URL

### DIFF
--- a/docker/webserver/nginx.conf
+++ b/docker/webserver/nginx.conf
@@ -2,7 +2,7 @@ server {
   listen 80;
   server_name _;
   location / {
-    proxy_pass http://api:5000;
+    proxy_pass http://api:5000$query_string;
     proxy_set_header Host $host;
     proxy_set_header X-Real-Ip $remote_addr;
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;


### PR DESCRIPTION
The issue is likely caused by the fact that the webserver did not include the query string while proxy pass the request .