### PR TITLE
hotfix: includes origin header on the containerized webserver

### DIFF
--- a/docker/webserver/nginx.conf
+++ b/docker/webserver/nginx.conf
@@ -2,10 +2,13 @@ server {
   listen 80;
   server_name _;
   location / {
-    proxy_pass http://api:5000$query_string;
+    proxy_pass http://api:5000$request_uri;
     proxy_set_header Host $host;
     proxy_set_header X-Real-Ip $remote_addr;
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_set_header Origin $http_origin;
+    proxy_set_header Access-Control-Request-Headers $http_access_control_request_headers;
+    proxy_set_header Access-Control-Request-Method $http_access_control_request_method;
   }
 }


### PR DESCRIPTION
This makes it so that the origin header gets passed to the backend successfully.