### PR TITLE
hotfix: missing utm parameters on redirect

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ coverage/
 .cursor/
 TODO.md
 memory.md
+logs/

--- a/src/services/publicUrlService.ts
+++ b/src/services/publicUrlService.ts
@@ -48,9 +48,12 @@ export const getPublicUrlDetails = async (shortCode: string): Promise<any | null
     const baseUrl = process.env.SHORT_URL_BASE ?? 'https://cylink.id/';
     const shortUrl = baseUrl + url.short_code;
 
+    // Generate redirect URL with UTM campaigns
+    const redirectUrl = `${url.original_url}?${generateUtmParameters(url.short_code)}`;
+
     // Return only the required fields for public consumption
     return {
-      original_url: url.original_url,
+      original_url: redirectUrl,
       title: url.title ?? null,
       short_code: url.short_code,
       short_url: shortUrl,
@@ -64,6 +67,22 @@ export const getPublicUrlDetails = async (shortCode: string): Promise<any | null
     logger.error(`Error retrieving public URL details for ${shortCode}: ${errorMessage}`);
     throw new Error('Failed to retrieve URL details');
   }
+};
+
+/**
+ * Generate UTM parameters
+ * @param {string} shortCode - The short code for tracking
+ * @returns {string} - The query string with UTM parameters
+ */
+const generateUtmParameters = (shortCode: string): string => {
+  const searchParams = new URLSearchParams({
+    utm_source: 'cylink',
+    utm_medium: 'shortlink',
+    utm_campaign: 'conversion',
+    utm_content: encodeURIComponent(shortCode),
+  });
+
+  return searchParams.toString();
 };
 
 export default { getPublicUrlDetails };


### PR DESCRIPTION
## Description
Fixed the absence of UTM parameters when client wants to redirect to the original URL.

## Key Changes
- Appending UTM campaigns as query parameter on the original URL whenever client requested a public URL by short code

## Rationale for Changes
For scalability and future-proof solution to URL performance tracking.

## Type of Changes
- [x] New Feature: Appends UTM suffix into original public URL
- [ ] Documentation
- [ ] Bug fix
- [ ] Refactoring

# Known Issues and Future Improvements
- **Potential Ambiguous Business Process**: Currently when client creates a shortened link and tries to retrieve it via public URL endpoint, the backend will forcefully append the UTM campaigns. If the client's original URL already has its own UTM campaign, it will result in mixed UTM campaigns. The committer deliberately did not interfere with the business process to retain a flexible possibility, so that the final decision can be made later.