### PR TITLE
hotfix: empty swagger documentation

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,7 @@ services:
   api:
     image: ${DOCKERHUB_USERNAME}/${DOCKERHUB_APP_ID}:prod
     environment:
+      NODE_ENV: ${NODE_ENV}
       PORT: ${PORT}
       ENABLE_LOG: ${ENABLE_LOG}
       DATABASE_URL: postgres://${DATABASE_USER}:${DATABASE_PASSWORD}@database:5432/${DATABASE_NAME}


### PR DESCRIPTION
Caused by the absence of the NODE_ENV variable which was required on a ternary operator inside the src/config/swagger.ts file, to determine the swagger specification file location.