### PR TITLE
fix: sentry auth and logger utils

### DIFF
--- a/.github/workflows/deploy.dev.yml
+++ b/.github/workflows/deploy.dev.yml
@@ -22,6 +22,9 @@ jobs:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_TOKEN }}
 
+    - name: Login to Sentry CLI
+      run: sentry-cli login --auth-token ${{ secrets.SENTRY_AUTH_TOKEN }}
+
     - name: Build and push api image
       uses: docker/build-push-action@v5
       with:

--- a/.github/workflows/deploy.prod.yml
+++ b/.github/workflows/deploy.prod.yml
@@ -21,6 +21,9 @@ jobs:
       with:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_TOKEN }}
+    
+    - name: Login to Sentry CLI
+      run: sentry-cli login --auth-token ${{ secrets.SENTRY_AUTH_TOKEN }}
 
     - name: Build and push api image
       uses: docker/build-push-action@v5

--- a/.github/workflows/deploy.staging.yml
+++ b/.github/workflows/deploy.staging.yml
@@ -21,6 +21,9 @@ jobs:
       with:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_TOKEN }}
+    
+    - name: Login to Sentry CLI
+      run: sentry-cli login --auth-token ${{ secrets.SENTRY_AUTH_TOKEN }}
 
     - name: Build and push api image
       uses: docker/build-push-action@v5

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,6 +16,7 @@ import express, { json, urlencoded, Request, Response } from 'express';
 import { setupSwagger } from './middlewares/swagger';
 import { startScheduler } from './jobs/jobScheduler';
 import cors from 'cors';
+import logger from './utils/logger';
 
 import * as Sentry from '@sentry/node'; 
 const app = express();
@@ -47,6 +48,11 @@ setupSwagger(app);
 
 // API routes
 app.use('/api/v1', routes);
+
+app.get('/test', (req: any, res: any) => {
+  logger.error('test error', 'test error json');
+  return res.status(200).json({ message: 'test' });
+});
 
 // Sentry middleware
 Sentry.setupExpressErrorHandler(app);

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -19,21 +19,18 @@ const defaultFormat = [
   winston.format.printf(({ timestamp, level, message, ...args }: any) => {
     let log = `[${timestamp}] ${level.toUpperCase()}: ${message}`;
 
-    if (args) {
+    const keys = Object.keys(args);
+    if (keys.length > 0) {
       log += ': ';
 
-      const keys = Object.keys(args);
       if (
         // if stack is type of object-string
-        keys.length > 0
-        && keys.every(k => /^\d+$/.test(k)
+        keys.every(k => /^\d+$/.test(k)
         && typeof args[k] === 'string'
         && args[k].length === 1)
       ) {
-        const reconstructed = Object.keys(args)
-          .sort((a, b) => Number(a) - Number(b))
-          .map(key => args[key])
-          .join('');
+        const sortedKeys = [...keys].sort((a, b) => Number(a) - Number(b));
+        const reconstructed = sortedKeys.map(key => args[key]).join('');
         log += reconstructed;
       } else {
         log += JSON.stringify(args);

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -16,8 +16,31 @@ const defaultFormat = [
   winston.format.timestamp({ format: 'YYYY-MM-DD HH:mm:ss' }),
   winston.format.errors({ stack: true }),
   winston.format.splat(),
-  winston.format.printf(({ timestamp, level, message, stack }: any) => {
-    return `[${timestamp}] ${level.toUpperCase()}: ${message} ${stack || ''}`;
+  winston.format.printf(({ timestamp, level, message, ...args }: any) => {
+    let log = `[${timestamp}] ${level.toUpperCase()}: ${message}`;
+
+    if (args) {
+      log += ': ';
+
+      const keys = Object.keys(args);
+      if (
+        // if stack is type of object-string
+        keys.length > 0
+        && keys.every(k => /^\d+$/.test(k)
+        && typeof args[k] === 'string'
+        && args[k].length === 1)
+      ) {
+        const reconstructed = Object.keys(args)
+          .sort((a, b) => Number(a) - Number(b))
+          .map(key => args[key])
+          .join('');
+        log += reconstructed;
+      } else {
+        log += JSON.stringify(args);
+      }
+    }
+
+    return log;
   }),
 ];
 const logFormat = winston.format.combine(...defaultFormat);


### PR DESCRIPTION
# Changes
- [x] Added Sentry authentication key on the GitHub deployment workflow scripts.
- [x] Fixed Winston logger on console and file which works for both string and object-string error message type.